### PR TITLE
Solving "Open uri redirect forbidden" for http request 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,0 @@
-require "bundler/gem_tasks"
-task :default => :spec

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,2 @@
+require "bundler/gem_tasks"
+task :default => :spec

--- a/askwiki.gemspec
+++ b/askwiki.gemspec
@@ -11,4 +11,5 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/blazeeboy/askwiki'
   s.license     = 'MIT'
   s.require_paths = ['lib']
+  s.add_runtime_dependency 'open_uri_allow_redirect','0.0.1'
 end

--- a/lib/askwiki.rb
+++ b/lib/askwiki.rb
@@ -1,4 +1,4 @@
-require 'open-uri_allow_redirect'
+require 'open_uri_allow_redirect'
 require 'json'
 
 class Askwiki
@@ -6,19 +6,21 @@ class Askwiki
 
 
   def initialize( lang='en' )
-  @language = lang
+    @language = lang
   end
 
   def ask query
-  query_encoded = URI::encode(query)
-  request_url = "http://#{@language}.wikipedia.org/w/api.php?action=parse&page=#{query_encoded}&format=json&prop=text&section=0&redirects"
+    query_encoded = URI::encode(query)
+    request_url = "http://#{@language}.wikipedia.org/w/api.php?action=parse&page=#{query_encoded}&format=json&prop=text&section=0&redirects"
     text = ''
-  open(request_url) do |file|
-  text = JSON.parse(file.read())['parse']['text'].first[1]
-  .gsub(/<\/?[^>]+>/, '') # strip tags
-  .gsub(/[[:space:]]+/, ' ') # strip whitespace
-  .gsub(/&#[0-9]+;/,'') # strip encoded
-  .gsub(/\[[0-9]+\]/,'') # strip referencing
+    OpenURI.allow_redirect do
+      open(request_url) do |file|
+        text = JSON.parse(file.read())['parse']['text'].first[1]
+          .gsub(/<\/?[^>]+>/, '') # strip tags
+          .gsub(/[[:space:]]+/, ' ') # strip whitespace
+          .gsub(/&#[0-9]+;/,'') # strip encoded
+          .gsub(/\[[0-9]+\]/,'') # strip referencing
+      end
     end
     text
   end

--- a/lib/askwiki.rb
+++ b/lib/askwiki.rb
@@ -1,4 +1,4 @@
-require 'open-uri'
+require 'open-uri_allow_redirect'
 require 'json'
 
 class Askwiki
@@ -6,26 +6,26 @@ class Askwiki
 
 
   def initialize( lang='en' )
-  	@language = lang
+  @language = lang
   end
-  
+
   def ask query
-  	query_encoded = URI::encode(query)
-  	request_url = "http://#{@language}.wikipedia.org/w/api.php?action=parse&page=#{query_encoded}&format=json&prop=text&section=0&redirects"
+  query_encoded = URI::encode(query)
+  request_url = "http://#{@language}.wikipedia.org/w/api.php?action=parse&page=#{query_encoded}&format=json&prop=text&section=0&redirects"
     text = ''
-  	open(request_url) do |file|
-  	  text = JSON.parse(file.read())['parse']['text'].first[1]
-  	    .gsub(/<\/?[^>]+>/, '') # strip tags
-  	    .gsub(/[[:space:]]+/, ' ') # strip whitespace
-  	    .gsub(/&#[0-9]+;/,'') # strip encoded
-  	    .gsub(/\[[0-9]+\]/,'') # strip referencing
+  open(request_url) do |file|
+  text = JSON.parse(file.read())['parse']['text'].first[1]
+  .gsub(/<\/?[^>]+>/, '') # strip tags
+  .gsub(/[[:space:]]+/, ' ') # strip whitespace
+  .gsub(/&#[0-9]+;/,'') # strip encoded
+  .gsub(/\[[0-9]+\]/,'') # strip referencing
     end
     text
   end
 
   def self.ask( query, lang='en' )
-    ask_obj = Askwiki.new lang  
-    ask_obj.ask query 
+    ask_obj = Askwiki.new lang
+    ask_obj.ask query
   end
 
 end


### PR DESCRIPTION
I've noticed that you used (http) protocol instead of (https) when sending get request to Wikipedia.
Using http protocol causes open_uri redirect forbidden error. 

The solution is to add open_uri_rallow_redirect gem which is built on top of open_uri.

what i committed:
1- Adding open_uri_allow_redirect as a run time dependency
2- In file lib/askwiki.rb i changed open_uri to open_uri_allow_redirect and added OpenURI.allow_redirect which is a module method that takes a block(your open method wrapped in that block :) )
3- Removing my Rakefile which i created just to install the gem locally and make sure it worked and it did . 
